### PR TITLE
Do not spit out HTML in a CLI context.

### DIFF
--- a/spoon/exception/exception.php
+++ b/spoon/exception/exception.php
@@ -87,12 +87,13 @@ class SpoonException extends Exception
 }
 
 
-// redefine the exception handler
-set_exception_handler('exceptionHandler');
+// Redefine the exception handler if we are not running in the command line.
+if (!Spoon::inCli()) set_exception_handler('exceptionHandler');
 
 
 /**
- * Prints out the thrown exception in a more readable manner
+ * Prints out the thrown exception in a more readable manner for a person using
+ * a web browser.
  *
  * @return	void
  * @param	SpoonException $exception

--- a/spoon/spoon.php
+++ b/spoon/spoon.php
@@ -222,6 +222,17 @@ class Spoon
 
 
 	/**
+	 * Are we running in the command line?
+	 *
+	 * @return	bool
+	 */
+	public static function inCli()
+	{
+		return PHP_SAPI == 'cli';
+	}
+
+
+	/**
 	 * Registers a given value under a given name.
 	 *
 	 * @return	void


### PR DESCRIPTION
Spoon's exception handler might be nice when viewing the error message
in a web context, ie. with a browser, but when running stuff from the
command line, this is not readable, further more, it throws a notice
because $_SERVER['REQUEST_METHOD'] is not known in php-cli.

By checking in which context we are before registering the exception
handler, we prevent this.  In addition the cli check is put in the main
Spoon class since it may be useful in other places too.
