### PR TITLE
Type check elements of multi-checkbox.

### DIFF
--- a/spoon/form/multi_checkbox.php
+++ b/spoon/form/multi_checkbox.php
@@ -359,6 +359,8 @@ class SpoonFormMultiCheckbox extends SpoonFormElement
 		// loop values
 		foreach($values as $value)
 		{
+			if(!is_array($value)) throw new SpoonFormException('Each value should be an associative array with a "label" and "value" key.');
+
 			// label is not set
 			if(!isset($value['label'])) throw new SpoonFormException('Each element in this array should contain a key "label".');
 

--- a/tests/form/spoon_form_multi_checkbox_test.php
+++ b/tests/form/spoon_form_multi_checkbox_test.php
@@ -67,6 +67,35 @@ class SpoonMultiCheckBoxTest extends PHPUnit_Framework_TestCase
 		$this->chkHobbies->setAllowExternalData(true);
 		$this->assertEquals(array('bimbo', 'tramp', '10', '30'), $this->chkHobbies->getValue());
 	}
+
+	public function testNotSupplyingCorrectFormatThrowsException()
+	{
+		$values = array('12' => 'aaa', '132' => 'bbb', '32' => 'ccc');
+		$this->setExpectedException('SpoonFormException');
+		$c = new SpoonFormMultiCheckbox('test', $values);
+	}
+
+	public function testNotSupplyingLabelThrowsException()
+	{
+		$values = array(
+			array('value' => 'aaa'),
+			array('value' => 'bbb'),
+			array('value' => 'ccc')
+		);
+		$this->setExpectedException('SpoonFormException');
+		$c = new SpoonFormMultiCheckbox('test', $values);
+	}
+
+	public function testNotSupplyingValueThrowsException()
+	{
+		$values = array(
+			array('label' => 'aaa'),
+			array('label' => 'bbb'),
+			array('label' => 'ccc')
+		);
+		$this->setExpectedException('SpoonFormException');
+		$c = new SpoonFormMultiCheckbox('test', $values);
+	}
 }
 
 ?>


### PR DESCRIPTION
The multi checkbox works somewhat different than the drop down menu,
where you pass a mapping value => label.  This has lead to confusion
when working with the multi checkbox whereby checkboxes are displayed,
but only the first character of the label is shown.

At first I thought the isset($value['label']/['value']) was to blame,
but, while I'm still inclined to think using isset() for array key
existance checks is not a good idea, this was not the root of the
problem.  The fact that code in user land passes an assoc. array instead
of an array of assoc. arrays, is however.

By checking the type of each value, prevents this, while at the same
time leaving the rest of the production code in tact; none of the
isset() checks needed changing.  This check is also essential: using
isset($value['label]) doesn't throw an exception at all if $value was a
string instead of an assoc. array and, on the other hand: using
array_key_exists('label', $value) would throw a not so clear error
complaining about the second argument to array_key_exists() not being an
array.
