### PR TITLE
SpoonDatabase & SpoonFormHidden

### DIFF
--- a/spoon/database/database.php
+++ b/spoon/database/database.php
@@ -353,6 +353,26 @@ class SpoonDatabase
 		return $this->driver;
 	}
 
+	/**
+	 * Fetch the name of the database
+	 *
+	 * @return	string	The name of the database that is used.
+	 */
+	public function getDatabase()
+	{
+		return $this->driver;
+	}
+
+	/**
+	 * Clean up before serializing
+	 *
+	 * @return	array	The names of the variables to serialize.
+	 */
+	public function __sleep()
+	{
+		$this->handler = null;
+		return array_keys(get_object_vars($this));
+	}
 
 	/**
 	 * Retrieves the possible ENUM values

--- a/spoon/database/database.php
+++ b/spoon/database/database.php
@@ -122,6 +122,16 @@ class SpoonDatabase
 		$this->setPort($port);
 	}
 
+	/**
+	 * Clean up before serializing
+	 *
+	 * @return	array	The names of the variables to serialize.
+	 */
+	public function __sleep()
+	{
+		$this->handler = null;
+		return array_keys(get_object_vars($this));
+	}
 
 	/**
 	 * Creates a new database connection if it was not yet made.
@@ -331,6 +341,15 @@ class SpoonDatabase
 		return $statement->fetchAll(PDO::FETCH_COLUMN);
 	}
 
+	/**
+	 * Fetch the name of the database
+	 *
+	 * @return	string	The name of the database that is used.
+	 */
+	public function getDatabase()
+	{
+		return $this->database;
+	}
 
 	/**
 	 * Retrieve the debug setting
@@ -342,7 +361,6 @@ class SpoonDatabase
 		return $this->debug;
 	}
 
-
 	/**
 	 * Fetch the name of the database driver
 	 *
@@ -351,27 +369,6 @@ class SpoonDatabase
 	public function getDriver()
 	{
 		return $this->driver;
-	}
-
-	/**
-	 * Fetch the name of the database
-	 *
-	 * @return	string	The name of the database that is used.
-	 */
-	public function getDatabase()
-	{
-		return $this->driver;
-	}
-
-	/**
-	 * Clean up before serializing
-	 *
-	 * @return	array	The names of the variables to serialize.
-	 */
-	public function __sleep()
-	{
-		$this->handler = null;
-		return array_keys(get_object_vars($this));
 	}
 
 	/**

--- a/spoon/form/hidden.php
+++ b/spoon/form/hidden.php
@@ -106,7 +106,7 @@ class SpoonFormHidden extends SpoonFormAttributes
 	public function parse(SpoonTemplate $template = null)
 	{
 		// start html generation
-		$output = '<input type="hidden" value="' . $this->getValue() . '"';
+		$output = '<p style="display: none;"><input type="hidden" value="' . $this->getValue() . '"';
 
 		// build attributes
 		$attributes = array();
@@ -120,7 +120,7 @@ class SpoonFormHidden extends SpoonFormAttributes
 		// parse hidden field
 		if($template !== null) $template->assign('hid' . SpoonFilter::toCamelCase($this->attributes['name']), $output);
 
-		return $output;
+		return $output . '</p>' ;
 	}
 }
 

--- a/spoon/form/hidden.php
+++ b/spoon/form/hidden.php
@@ -106,7 +106,7 @@ class SpoonFormHidden extends SpoonFormAttributes
 	public function parse(SpoonTemplate $template = null)
 	{
 		// start html generation
-		$output = '<p style="display: none;"><input type="hidden" value="' . $this->getValue() . '"';
+		$output = '<div><input type="hidden" value="' . $this->getValue() . '"';
 
 		// build attributes
 		$attributes = array();
@@ -120,7 +120,7 @@ class SpoonFormHidden extends SpoonFormAttributes
 		// parse hidden field
 		if($template !== null) $template->assign('hid' . SpoonFilter::toCamelCase($this->attributes['name']), $output);
 
-		return $output . '</p>' ;
+		return $output . '</div>' ;
 	}
 }
 


### PR DESCRIPTION
1. There was no database getter yet, I think it would be interesting to have one.
2. When serializing a SpoonDatabase object with an initialized handler, an error gets thrown because PDO objects cannot be serialized. I suggest the implementation of __sleep(), allowing a SpoonDatabase object to get serialized.
3. An attempt to fix HTML validation for SpoonFormHidden.

(!) I accidently left 'return $this->driver;' instead of 'return $this->database;' in getDatabase() >.<
