### PR TITLE
Spoon: make the exception handler more usable

### DIFF
--- a/spoon/exception/exception.php
+++ b/spoon/exception/exception.php
@@ -451,6 +451,8 @@ function dimCommonPathPrefix($path)
 			htmlspecialchars(substr($path, strlen($prefix) + 1))
 		);
 
-	// wrap it using soft hyphens
-	return preg_replace('@[^<]/@', '$0<wbr/>', $html);
+	// insert word break hints to avoid overly long lines
+	$html = preg_replace('@[^<]/@', '$0<wbr/>', $html);
+
+	return $html;
 }

--- a/spoon/exception/exception.php
+++ b/spoon/exception/exception.php
@@ -115,7 +115,7 @@ function exceptionHandler($exception)
 	if(!isset($_SERVER['REQUEST_URI'])) $_SERVER['REQUEST_URI'] = '';
 
 	// user agent
-	$userAgent = isset($_SERVER['HTTP_USER_AGENT']) ? $_SERVER['HTTP_USER_AGENT'] : 'unknown';
+	$userAgent = isset($_SERVER['HTTP_USER_AGENT']) ? $_SERVER['HTTP_USER_AGENT'] : '<i>(Unknown)</i>';
 
 	// generate output
 	$output = '
@@ -139,7 +139,7 @@ function exceptionHandler($exception)
 										</tr>
 										<tr>
 											<th width="110px" style="vertical-align: top; text-align: left; font-weight: 700; padding: 0 0 0 10px; font-family: Verdana, Tahoma, Arial; font-size: 10px; color: #000000;">File</th>
-											<td style="vertical-align: top; font-family: Verdana, Tahoma, Arial; font-size: 10px; color: #000000;">' . wordwrap($exception->getFile(), 70, '<br />', true) . '</td>
+											<td style="vertical-align: top; font-family: Verdana, Tahoma, Arial; font-size: 10px; color: #000000;">' . wordwrap($exception->getFile(), 70, '&shy;', true) . '</td>
 										</tr>
 										<tr>
 											<th width="110px" style="vertical-align: top; text-align: left; font-weight: 700; padding: 0 0 0 10px; font-family: Verdana, Tahoma, Arial; font-size: 10px; color: #000000;">Line</th>
@@ -164,7 +164,7 @@ function exceptionHandler($exception)
 		{
 			$output .= '						<a href="' . $_SERVER['HTTP_REFERER'] . '">' . $_SERVER['HTTP_REFERER'] . '</a>' . "\n";
 		}
-		else $output .= '						Unknown Referrer' . "\n";
+		else $output .= '						<i>(Unknown)</i>' . "\n";
 
 		$output .= '						</td>
 										</tr>
@@ -198,74 +198,6 @@ function exceptionHandler($exception)
 										</tr>';
 		}
 
-		// continue output
-		$output .= '				</table>
-								</td>
-							<tr>
-							<tr>
-								<td style="vertical-align: top; font-family: Verdana, Tahoma, Arial; font-size: 10px; color: #000000;">&nbsp;</td>
-							</tr>
-							<!-- variables -->
-							<tr>
-								<td style="background-color: #EEEEEE; border: 1px solid #B2B2B2;">
-									<h1 style="font-size: 12px; margin: 5px 5px 12px 5px; padding: 0 0 5px 0; color: #000000; font-family: Verdana, Tahoma, Arial; border-bottom: 1px solid #999999;">' . $name . ' &raquo; Variables</h1>
-									<table width="550px;">' . "\n";
-
-		// $_GET has items
-		if(isset($_GET))
-		{
-			$output .= '				<tr>
-											<th width="110px" style="vertical-align: top; text-align: left; font-weight: 700; padding: 0 0 0 10px; font-family: Verdana, Tahoma, Arial; font-size: 10px; color: #000000;">$_GET</th>
-											<td style="vertical-align: top; font-family: Verdana, Tahoma, Arial; font-size: 10px; color: #000000;">
-												<pre style="font-family: Courier; margin-bottom: 10px;">' . print_r($_GET, true) . '</pre>
-											</td>
-										</tr>' . "\n";
-		}
-
-		// $_POST has items
-		if(isset($_POST))
-		{
-			$output .= '				<tr>
-											<th width="110px" style="vertical-align: top; text-align: left; font-weight: 700; padding: 0 0 0 10px; font-family: Verdana, Tahoma, Arial; font-size: 10px; color: #000000;">$_POST</th>
-											<td style="vertical-align: top; font-family: Verdana, Tahoma, Arial; font-size: 10px; color: #000000;">
-												<pre style="font-family: Courier; margin-bottom: 10px;">' . print_r($_POST, true) . '</pre>
-											</td>
-										</tr>';
-		}
-
-		// $_SESSION has items
-		if(isset($_SESSION))
-		{
-			$output .= '				<tr>
-											<th width="110px" style="vertical-align: top; text-align: left; font-weight: 700; padding: 0 0 0 10px; font-family: Verdana, Tahoma, Arial; font-size: 10px; color: #000000;">$_SESSION</th>
-											<td style="vertical-align: top; font-family: Verdana, Tahoma, Arial; font-size: 10px; color: #000000;">
-												<pre style="font-family: Courier; margin-bottom: 10px;">' . print_r($_SESSION, true) . '</pre>
-											</td>
-										</tr>';
-		}
-
-		// $_COOKIE has items
-		if(isset($_COOKIE))
-		{
-			$output .= '				<tr>
-											<th width="110px" style="vertical-align: top; text-align: left; font-weight: 700; padding: 0 0 0 10px; font-family: Verdana, Tahoma, Arial; font-size: 10px; color: #000000;">$_COOKIE</th>
-											<td style="vertical-align: top; font-family: Verdana, Tahoma, Arial; font-size: 10px; color: #000000;">
-												<pre style="font-family: Courier; margin-bottom: 10px;">' . print_r($_COOKIE, true) . '</pre>
-											</td>
-										</tr>';
-		}
-
-		// $_FILES has items
-		if(isset($_FILES))
-		{
-			$output .= '				<tr>
-											<th width="110px" style="vertical-align: top; text-align: left; font-weight: 700; padding: 0 0 0 10px; font-family: Verdana, Tahoma, Arial; font-size: 10px; color: #000000;">$_FILES</th>
-											<td style="vertical-align: top; font-family: Verdana, Tahoma, Arial; font-size: 10px; color: #000000;">
-												<pre style="font-family: Courier; margin-bottom: 10px;">' . print_r($_FILES, true) . '</pre>
-											</td>
-										</tr>';
-		}
-
 		$output .= '				</table>
 								</td>
 							</tr>
@@ -290,10 +222,10 @@ function exceptionHandler($exception)
 				// open defintion list
 				$output .= '			<tr>
 											<td style="vertical-align: top; font-family: Verdana, Tahoma, Arial; font-size: 10px; color: #000000;">
-												<table width="550px;">
+												<table width="550px;" style="border-top: 1px dotted; padding-top: 1ex;">
 													<tr>
 														<th width="110px" style="vertical-align: top; text-align: left; font-weight: 700; padding: 0 0 0 10px; font-family: Verdana, Tahoma, Arial; font-size: 10px; color: #000000;">File</th>
-														<td style="vertical-align: top; font-family: Verdana, Tahoma, Arial; font-size: 10px; color: #000000;">' . ((isset($traceStack['file'])) ? wordwrap($traceStack['file'], 70, '<br />', true) : 'Unknown') . '
+														<td style="vertical-align: top; font-family: Verdana, Tahoma, Arial; font-size: 10px; color: #000000;">' . ((isset($traceStack['file'])) ? wordwrap($traceStack['file'], 70, '&shy;', true) : 'Unknown') . '
 														</td>
 													</tr>
 													<tr>
@@ -305,17 +237,22 @@ function exceptionHandler($exception)
 				// class & function
 				if(isset($traceStack['class']))
 				{
+					$docUrl = 'http://www.google.com/search?btnI=&ie=utf-8&sourceid=navclient&q=' . urlencode(sprintf('site:php.net/manual OR site:www.spoon-library.com/docs class "%s"', $traceStack['class']));
+					$link = sprintf('<a href="%s">%s</a>', htmlspecialchars($docUrl), htmlspecialchars($traceStack['class']));
 					$output .= '					<tr>
 														<th width="110px" style="vertical-align: top; text-align: left; font-weight: 700; padding: 0 0 0 10px; font-family: Verdana, Tahoma, Arial; font-size: 10px; color: #000000;">Class</th>
-														<td style="vertical-align: top; font-family: Verdana, Tahoma, Arial; font-size: 10px; color: #000000;">' . $traceStack['class'] . '
-														</td>
+														<td style="vertical-align: top; font-family: Verdana, Tahoma, Arial; font-size: 10px; color: #000000;">' . $link . '</td>
 													</tr>';
 				}
 				if(isset($traceStack['function']))
 				{
+					$docUrl = isset($traceStack['class'])
+						? 'http://www.google.com/search?btnI=&ie=utf-8&sourceid=navclient&q=' . urlencode(sprintf('site:php.net/manual OR site:www.spoon-library.com/docs "%s::%s"', $traceStack['class'], $traceStack['function']))
+						: 'http://www.google.com/search?btnI=&ie=utf-8&sourceid=navclient&q=' . urlencode(sprintf('site:php.net/manual OR site:www.spoon-library.com/docs "%s"', $traceStack['function']));
+					$link = sprintf('<a href="%s">%s</a>', htmlspecialchars($docUrl), htmlspecialchars($traceStack['function']));
 					$output .= '					<tr>
 														<th width="110px" style="vertical-align: top; text-align: left; font-weight: 700; padding: 0 0 0 10px; font-family: Verdana, Tahoma, Arial; font-size: 10px; color: #000000;">Function</th>
-														<td style="vertical-align: top; font-family: Verdana, Tahoma, Arial; font-size: 10px; color: #000000;">' . $traceStack['function'] . '													</td>
+														<td style="vertical-align: top; font-family: Verdana, Tahoma, Arial; font-size: 10px; color: #000000;">' . $link . '</td>
 													</tr>';
 				}
 
@@ -326,7 +263,7 @@ function exceptionHandler($exception)
 					$output .= '					<tr>
 														<th width="110px" style="vertical-align: top; text-align: left; font-weight: 700; padding: 0 0 0 10px; font-family: Verdana, Tahoma, Arial; font-size: 10px; color: #000000;">Argument(s)</th>
 														<td style="vertical-align: top; font-family: Verdana, Tahoma, Arial; font-size: 10px; color: #000000;">
-															<pre style="font-family: Courier; margin-bottom: 10px;">' . print_r($traceStack['args'], true) . '</pre>
+															<pre style="font-family: Courier; margin-bottom: 10px;">' . exceptionHandlerDumper($traceStack['args']) . '</pre>
 														</td>
 													</tr>';
 				}
@@ -342,6 +279,33 @@ function exceptionHandler($exception)
 		else $output .= '				<tr>
 											<td style="vertical-align: top; font-family: Verdana, Tahoma, Arial; font-size: 10px; color: #000000;">No trace available.</td>
 										</tr>';
+
+		// continue output
+		$output .= '				</table>
+								</td>
+							<tr>
+							<tr>
+								<td style="vertical-align: top; font-family: Verdana, Tahoma, Arial; font-size: 10px; color: #000000;">&nbsp;</td>
+							</tr>
+							<!-- variables -->
+							<tr>
+								<td style="background-color: #EEEEEE; border: 1px solid #B2B2B2;">
+									<h1 style="font-size: 12px; margin: 5px 5px 12px 5px; padding: 0 0 5px 0; color: #000000; font-family: Verdana, Tahoma, Arial; border-bottom: 1px solid #999999;">' . $name . ' &raquo; Variables</h1>
+									<table width="550px;">' . "\n";
+
+		foreach(array('GET', 'POST', 'COOKIE', 'FILES') as $superGlobal)
+		{
+			if(!empty($GLOBALS['_' . $superGlobal]))
+			{
+				$output .= '				<tr>
+												<th width="110px" style="vertical-align: top; text-align: left; font-weight: 700; padding: 0 10px 0 10px; font-family: Verdana, Tahoma, Arial; font-size: 10px; color: #000000;">$_' . $superGlobal . '</th>
+												<td style="vertical-align: top; font-family: Verdana, Tahoma, Arial; font-size: 10px; color: #000000;">
+													<pre style="font-family: Courier; margin-bottom: 10px;">' . exceptionHandlerDumper($GLOBALS['_' . $superGlobal]) . '</pre>
+												</td>
+											</tr>' . "\n";
+			}
+		}
+
 		// continue output generation
 		$output .= '				</table>
 								</td>
@@ -422,4 +386,36 @@ function exceptionHandler($exception)
 
 	// stop script execution
 	exit;
+}
+
+
+/**
+ * Helper function for the exception handler to pretty-print variables.
+ *
+ * @return	void
+ * @param	SpoonException $exception
+ */
+function exceptionHandlerDumper($exception)
+{
+	ob_start();
+	foreach (func_get_args() as $arg)
+	{
+		if (is_string($arg))
+		{
+			echo $arg;
+		}
+		else
+		{
+			ob_start();
+			var_dump($arg);
+			$output = ob_get_clean();
+			echo substr($output, 0, -1);
+		}
+	}
+	$dump = ob_get_clean();
+	return preg_replace(
+		array('@{\n}@', '@#[0-9]+@', '@\]=>\n\s*@'),
+		array('{ }', '', '] => '),
+		$dump
+	);
 }

--- a/spoon/exception/exception.php
+++ b/spoon/exception/exception.php
@@ -225,12 +225,12 @@ function exceptionHandler($exception)
 												<table width="550px;" style="border-top: 1px dotted; padding-top: 1ex;">
 													<tr>
 														<th width="110px" style="vertical-align: top; text-align: left; font-weight: 700; padding: 0 0 0 10px; font-family: Verdana, Tahoma, Arial; font-size: 10px; color: #000000;">File</th>
-														<td style="vertical-align: top; font-family: Verdana, Tahoma, Arial; font-size: 10px; color: #000000;">' . ((isset($traceStack['file'])) ? wordwrap($traceStack['file'], 70, '&shy;', true) : 'Unknown') . '
+														<td style="vertical-align: top; font-family: Verdana, Tahoma, Arial; font-size: 10px; color: #000000;">' . ((isset($traceStack['file'])) ? wordwrap($traceStack['file'], 70, '&shy;', true) : '<i>(Unknown)</i>') . '
 														</td>
 													</tr>
 													<tr>
 														<th width="110px" style="vertical-align: top; text-align: left; font-weight: 700; padding: 0 0 0 10px; font-family: Verdana, Tahoma, Arial; font-size: 10px; color: #000000;">Line</th>
-														<td style="vertical-align: top; font-family: Verdana, Tahoma, Arial; font-size: 10px; color: #000000;">' . ((isset($traceStack['line'])) ? $traceStack['line'] : 'Unknown') . '
+														<td style="vertical-align: top; font-family: Verdana, Tahoma, Arial; font-size: 10px; color: #000000;">' . ((isset($traceStack['line'])) ? $traceStack['line'] : '<i>(Unknown)</i>') . '
 														</td>
 													</tr>';
 

--- a/spoon/exception/exception.php
+++ b/spoon/exception/exception.php
@@ -452,5 +452,5 @@ function dimCommonPathPrefix($path)
 		);
 
 	// wrap it using soft hyphens
-	return preg_replace('@[^<]/@', '$0&shy', $html);
+	return preg_replace('@[^<]/@', '$0<wbr/>', $html);
 }

--- a/spoon/exception/exception.php
+++ b/spoon/exception/exception.php
@@ -280,29 +280,38 @@ function exceptionHandler($exception)
 											<td style="vertical-align: top; font-family: Verdana, Tahoma, Arial; font-size: 10px; color: #000000;">No trace available.</td>
 										</tr>';
 
-		// continue output
-		$output .= '				</table>
-								</td>
-							<tr>
-							<tr>
-								<td style="vertical-align: top; font-family: Verdana, Tahoma, Arial; font-size: 10px; color: #000000;">&nbsp;</td>
-							</tr>
-							<!-- variables -->
-							<tr>
-								<td style="background-color: #EEEEEE; border: 1px solid #B2B2B2;">
-									<h1 style="font-size: 12px; margin: 5px 5px 12px 5px; padding: 0 0 5px 0; color: #000000; font-family: Verdana, Tahoma, Arial; border-bottom: 1px solid #999999;">' . $name . ' &raquo; Variables</h1>
-									<table width="550px;">' . "\n";
-
+		// output the superglobal variables, if any
+		$hasVars = false;
 		foreach(array('GET', 'POST', 'COOKIE', 'FILES') as $superGlobal)
 		{
-			if(!empty($GLOBALS['_' . $superGlobal]))
+			$hasVars |= count($GLOBALS['_' . $superGlobal]);
+		}
+
+		if($hasVars)
+		{
+			$output .= '				</table>
+									</td>
+								<tr>
+								<tr>
+									<td style="vertical-align: top; font-family: Verdana, Tahoma, Arial; font-size: 10px; color: #000000;">&nbsp;</td>
+								</tr>
+								<!-- variables -->
+								<tr>
+									<td style="background-color: #EEEEEE; border: 1px solid #B2B2B2;">
+										<h1 style="font-size: 12px; margin: 5px 5px 12px 5px; padding: 0 0 5px 0; color: #000000; font-family: Verdana, Tahoma, Arial; border-bottom: 1px solid #999999;">' . $name . ' &raquo; Variables</h1>
+										<table width="550px;">' . "\n";
+
+			foreach(array('GET', 'POST', 'COOKIE', 'FILES') as $superGlobal)
 			{
-				$output .= '				<tr>
-												<th width="110px" style="vertical-align: top; text-align: left; font-weight: 700; padding: 0 10px 0 10px; font-family: Verdana, Tahoma, Arial; font-size: 10px; color: #000000;">$_' . $superGlobal . '</th>
-												<td style="vertical-align: top; font-family: Verdana, Tahoma, Arial; font-size: 10px; color: #000000;">
-													<pre style="font-family: Courier; margin-bottom: 10px;">' . exceptionHandlerDumper($GLOBALS['_' . $superGlobal]) . '</pre>
-												</td>
-											</tr>' . "\n";
+				if(!empty($GLOBALS['_' . $superGlobal]))
+				{
+					$output .= '				<tr>
+													<th width="110px" style="vertical-align: top; text-align: left; font-weight: 700; padding: 0 10px 0 10px; font-family: Verdana, Tahoma, Arial; font-size: 10px; color: #000000;">$_' . $superGlobal . '</th>
+													<td style="vertical-align: top; font-family: Verdana, Tahoma, Arial; font-size: 10px; color: #000000;">
+														<pre style="font-family: Courier; margin-bottom: 10px;">' . exceptionHandlerDumper($GLOBALS['_' . $superGlobal]) . '</pre>
+													</td>
+												</tr>' . "\n";
+				}
 			}
 		}
 

--- a/spoon/exception/exception.php
+++ b/spoon/exception/exception.php
@@ -392,10 +392,11 @@ function exceptionHandler($exception)
 /**
  * Helper function for the exception handler to pretty-print variables.
  *
- * @return	void
- * @param	SpoonException $exception
+ * @return	string
+ * @param	mixed $var	A variable to dump
+ * @param	mixed[optional] $varN	Zero or more variables to dump.
  */
-function exceptionHandlerDumper($exception)
+function exceptionHandlerDumper($var)
 {
 	ob_start();
 	foreach (func_get_args() as $arg)

--- a/spoon/exception/exception.php
+++ b/spoon/exception/exception.php
@@ -139,7 +139,7 @@ function exceptionHandler($exception)
 										</tr>
 										<tr>
 											<th width="110px" style="vertical-align: top; text-align: left; font-weight: 700; padding: 0 0 0 10px; font-family: Verdana, Tahoma, Arial; font-size: 10px; color: #000000;">File</th>
-											<td style="vertical-align: top; font-family: Verdana, Tahoma, Arial; font-size: 10px; color: #000000;">' . wordwrap($exception->getFile(), 70, '&shy;', true) . '</td>
+											<td style="vertical-align: top; font-family: Verdana, Tahoma, Arial; font-size: 10px; color: #000000;">' . dimCommonPathPrefix($exception->getFile()) . '</td>
 										</tr>
 										<tr>
 											<th width="110px" style="vertical-align: top; text-align: left; font-weight: 700; padding: 0 0 0 10px; font-family: Verdana, Tahoma, Arial; font-size: 10px; color: #000000;">Line</th>
@@ -225,7 +225,7 @@ function exceptionHandler($exception)
 												<table width="550px;" style="border-top: 1px dotted; padding-top: 1ex;">
 													<tr>
 														<th width="110px" style="vertical-align: top; text-align: left; font-weight: 700; padding: 0 0 0 10px; font-family: Verdana, Tahoma, Arial; font-size: 10px; color: #000000;">File</th>
-														<td style="vertical-align: top; font-family: Verdana, Tahoma, Arial; font-size: 10px; color: #000000;">' . ((isset($traceStack['file'])) ? wordwrap($traceStack['file'], 70, '&shy;', true) : '<i>(Unknown)</i>') . '
+														<td style="vertical-align: top; font-family: Verdana, Tahoma, Arial; font-size: 10px; color: #000000;">' . ((isset($traceStack['file'])) ? dimCommonPathPrefix($traceStack['file']) : '<i>(Unknown)</i>') . '
 														</td>
 													</tr>
 													<tr>
@@ -419,4 +419,38 @@ function exceptionHandlerDumper($var)
 		array('{ }', '', '] => '),
 		$dump
 	);
+}
+
+
+/**
+ * Get the HTML with the longest common path for this file and the given
+ * path dimmed.
+ *
+ * @param	string $path	The path to compare against this file's path.
+ * @return	string
+ */
+function dimCommonPathPrefix($path)
+{
+	// determine the longest shared prefix
+	$prefix = dirname(__FILE__);
+	while(!empty($prefix) && $prefix !== '/' && $prefix !== '.')
+	{
+		if(strpos($path, $prefix . DIRECTORY_SEPARATOR) === 0)
+		{
+			break;
+		}
+		$prefix = dirname($prefix);
+	}
+
+	// generate the HTML to dim the prefix, if any
+	$html = empty($prefix) || $prefix === '/' || $prefix === '.'
+		? htmlspecialchars($path)
+		: sprintf(
+			'<span style="opacity: 0.33">%s/</span>%s',
+			htmlspecialchars($prefix),
+			htmlspecialchars(substr($path, strlen($prefix) + 1))
+		);
+
+	// wrap it using soft hyphens
+	return preg_replace('@[^<]/@', '$0&shy', $html);
 }


### PR DESCRIPTION
- Separate the stack entries
- Show the stack trace before the superglobals
- Link to PHP/Spoon class and function documentation (with Google's best guess)
- Only show the superglobals that are not empty
- Visually indicate empty referrers and user agents
- Use word break hints instead of hard line breaks for long paths
- Dim the common path prefix so the relevant part of the source file's path stands out

Note that this is still bile solidified as code, but it is at least slightly
better. Now if only someone would unfuck the wretched tag soup that is its
output…

This is a big ol' commit instead of atomic changes. My appy polly loggies.
