### PR TITLE
Spoon{File,Directory}: try to use 0666 for files

### DIFF
--- a/spoon/directory/directory.php
+++ b/spoon/directory/directory.php
@@ -36,7 +36,7 @@ class SpoonDirectory
 	 * @param	string $destination			The full path to the destination.
 	 * @param	bool[optional] $overwrite	If the destination already exists, should we overwrite?
 	 * @param	bool[optional] $strict		If strict is true, exceptions will be thrown when an error occures.
-	 * @param 	int[optional] $chmod		Mode that will be applied on the file/directory.
+	 * @param	int[optional] $chmod		Chmod mode that should be applied on the directory/file. Defaults to 0777 (+rwx for all) for directories and 0666 (+rw for all) for files.
 	 */
 	public static function copy($source, $destination, $overwrite = true, $strict = true, $chmod = 0777)
 	{
@@ -44,6 +44,10 @@ class SpoonDirectory
 		$source = (string) $source;
 		$destination = (string) $destination;
 		$return = true;
+		if($chmod === null)
+		{
+			$chmod = is_dir($source) ? 0777 : 0666;
+		}
 
 		// validation
 		if($strict)
@@ -396,14 +400,18 @@ class SpoonDirectory
 	 * @param	string $source				Path of the source directory.
 	 * @param	string $destination			Path of the destination.
 	 * @param 	bool[optional] $overwrite	Should an existing directory be overwritten?
-	 * @param	int[optional] $chmod		Mode that should be applied on the directory.
+	 * @param	int[optional] $chmod		Chmod mode that should be applied on the directory/file. Defaults to 0777 (+rwx for all) for directories and 0666 (+rw for all) for files.
 	 */
-	public static function move($source, $destination, $overwrite = true, $chmod = 0777)
+	public static function move($source, $destination, $overwrite = true, $chmod = null)
 	{
 		// redefine vars
 		$source = (string) $source;
 		$destination = (string) $destination;
 		$overwrite = (bool) $overwrite;
+		if($chmod === null)
+		{
+			$chmod = is_dir($source) ? 0777 : 0666;
+		}
 
 		// validation
 		if(!file_exists($source)) throw new SpoonDirectoryException('The given path (' . $source . ') doesn\'t exist.');

--- a/spoon/directory/directory.php
+++ b/spoon/directory/directory.php
@@ -38,7 +38,7 @@ class SpoonDirectory
 	 * @param	bool[optional] $strict		If strict is true, exceptions will be thrown when an error occures.
 	 * @param	int[optional] $chmod		Chmod mode that should be applied on the directory/file. Defaults to 0777 (+rwx for all) for directories and 0666 (+rw for all) for files.
 	 */
-	public static function copy($source, $destination, $overwrite = true, $strict = true, $chmod = 0777)
+	public static function copy($source, $destination, $overwrite = true, $strict = true, $chmod = null)
 	{
 		// redefine vars
 		$source = (string) $source;

--- a/spoon/file/file.php
+++ b/spoon/file/file.php
@@ -281,10 +281,15 @@ class SpoonFile
 	 * @param	string $source				Path of the source file.
 	 * @param	string $destination			Path of the destination.
 	 * @param 	bool[optional] $overwrite	Should an existing file be overwritten?
-	 * @param	int[optional] $chmod		Chmod mode that should be applied on the file/directory.
+	 * @param	int[optional] $chmod		Chmod mode that should be applied on the file/directory. Defaults to 0777 (+rwx for all) for directories and 0666 (+rw for all) for files.
 	 */
-	public static function move($source, $destination, $overwrite = true, $chmod = 0777)
+	public static function move($source, $destination, $overwrite = true, $chmod = null)
 	{
+		if($chmod === null)
+		{
+			$chmod = is_dir($source) ? 0777 : 0666;
+		}
+
 		return SpoonDirectory::move($source, $destination, $overwrite, $chmod);
 	}
 
@@ -299,7 +304,7 @@ class SpoonFile
 	 * @param	bool[optional] $append		Should the content be appended if the file already exists?
 	 * @param	int[optional] $chmod		Mode that should be applied on the file.
 	 */
-	public static function setContent($filename, $content, $createFile = true, $append = false, $chmod = 0777)
+	public static function setContent($filename, $content, $createFile = true, $append = false, $chmod = 0666)
 	{
 		// redefine vars
 		$filename = (string) $filename;

--- a/spoon/thumbnail/thumbnail.php
+++ b/spoon/thumbnail/thumbnail.php
@@ -207,7 +207,7 @@ class SpoonThumbnail
 	 * @param	int[optional] $quality		The quality to use (only applies on jpg-images).
 	 * @param	int[optional] $chmod		Mode that should be applied on the file.
 	 */
-	public function parseToFile($filename, $quality = 100, $chmod = 0777)
+	public function parseToFile($filename, $quality = 100, $chmod = 0666)
 	{
 		// redefine vars
 		$filename = (string) $filename;


### PR DESCRIPTION
There is typically no need for files used by web applications to be executable.
In fact, it might make it slightly easier for attackers to do nasty things.
What use is an executable JPEG, for instance?

This does not address my general concern about permissions being too open: why
would you want the web server to generate files that are overwritable by other
users? In general, shared hosting running under the same user (`www-data`, for
instance) is at risk anyway, and hosting with `suEXEC`-like configurations that
run as a specific user (e.g. `joebloggs`) should definitely not make the files
overwritable by others.
