### PR TITLE
TemplateMod: date(): convert strings to timestamps

### DIFF
--- a/spoon/template/modifiers.php
+++ b/spoon/template/modifiers.php
@@ -82,6 +82,11 @@ class SpoonTemplateModifiers
 	 */
 	public static function date($timestamp, $format = 'Y-m-d H:i:s', $language = 'en')
 	{
+		if(is_string($timestamp) && !is_numeric($timestamp))
+		{
+			// use strptime if you want to restrict the input format
+			$timestamp = strtotime($timestamp);
+		}
 		return SpoonDate::getDate($format, $timestamp, $language);
 	}
 


### PR DESCRIPTION
"Be liberal in what you accept": it is inconvenient to have to
    SELECT *, UNIX_TIMESTAMP(starts_on) AS starts_on

Make the "date" template modifier convert string dates to timestamps.
