### PR TITLE
Fixed a bug where the default element would never return a value with ->g

### DIFF
--- a/spoon/form/dropdown.php
+++ b/spoon/form/dropdown.php
@@ -606,6 +606,7 @@ class SpoonFormDropdown extends SpoonFormAttributes
 	public function setDefaultElement($label, $value = null)
 	{
 		$this->defaultElement = array((string) $label, (string) $value);
+		if($value != null) $this->values[$value] = (string) $label;
 		return $this;
 	}
 


### PR DESCRIPTION
Fixed a bug where the default element would never return a value with ->getValue(); even when it has a value.
