### PR TITLE
Dropdownfix

### DIFF
--- a/spoon/form/dropdown.php
+++ b/spoon/form/dropdown.php
@@ -606,6 +606,7 @@ class SpoonFormDropdown extends SpoonFormAttributes
 	public function setDefaultElement($label, $value = null)
 	{
 		$this->defaultElement = array((string) $label, (string) $value);
+		if($value != null) $this->values[$value] = (string) $label;
 		return $this;
 	}
 

--- a/spoon/form/dropdown.php
+++ b/spoon/form/dropdown.php
@@ -464,6 +464,9 @@ class SpoonFormDropdown extends SpoonFormAttributes
 		// default element?
 		if(count($this->defaultElement) != 0)
 		{
+			// skip the default element
+			if(isset($this->defaultElement[1]) && $this->defaultElement[1] == $label) continue;
+
 			// create option
 			$output .= "\t" . '<option value="' . $this->defaultElement[1] . '"';
 


### PR DESCRIPTION
A default element would always have NULL as value when you did $ddmField->getValue(); This is now fixed.
