### PR TITLE
Removes bare LFs before sending mails

### DIFF
--- a/spoon/CHANGELOG
+++ b/spoon/CHANGELOG
@@ -13,6 +13,7 @@
 - SpoonFormTime::isValid now is a bit more precise and doesn't allow extra characters.
 - Added some basic getters to SpoonDatabase
 - SpoonFormDropDown will now allow you to combine option groups and regular values.
+- Bugfix: Removes bare LFs so mailservers don't freak out.
 
 1.3.0 (2011-02-18)
 ----

--- a/spoon/email/smtp.php
+++ b/spoon/email/smtp.php
@@ -352,6 +352,9 @@ class SpoonEmailSMTP
 		// code 354 means we can continue
 		if($this->repliedCode === 354)
 		{
+			// get rid of bare LFs
+			$data = str_replace("\n", "\r\n", $data);
+
 			// push our data
 			$this->say($data . self::CRLF . '.');
 

--- a/spoon/email/smtp.php
+++ b/spoon/email/smtp.php
@@ -11,6 +11,7 @@
  *
  *
  * @author		Davy Hellemans <davy@spoon-library.com>
+ * @author		Sam Tubbax <sam@sumocoders.be>
  * @since		1.0.0
  */
 


### PR DESCRIPTION
Removes bare LFs before sending mails.(Cause this (http://cr.yp.to/docs/smtplf.html) told me to)
