### PR TITLE
Escape field name

### DIFF
--- a/spoon/datagrid/source_db.php
+++ b/spoon/datagrid/source_db.php
@@ -130,7 +130,7 @@ class SpoonDatagridSourceDB extends SpoonDatagridSource
 		$query = $this->query;
 
 		// order & sort defined
-		if($order !== null && $sort !== null) $query .= ' ORDER BY ' . $order . ' ' . $sort;
+		if($order !== null && $sort !== null) $query .= ' ORDER BY `' . $order . '` ' . $sort;
 
 		// offset & limit defined
 		if($offset !== null && $limit !== null) $query .= ' LIMIT ' . $offset . ', ' . $limit;


### PR DESCRIPTION
Added back ticks to getData query, because if field name is group, then query fails
